### PR TITLE
Prepare for open a pull request

### DIFF
--- a/vs2012/Precomp/Precomf.vcxproj
+++ b/vs2012/Precomp/Precomf.vcxproj
@@ -35,35 +35,53 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseMT|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseMT|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
LZMA SDK (Software Development Kit)

The LZMA SDK provides the documentation, samples, header files, libraries, and tools you need to develop applications that use LZMA compression.

> Link  Size    Date    Version Description
> Download  1 MB    2016-05-21  16.02   LZMA SDK (C, C++, C#, Java) (with binaries for Windows)
> Download  12 KB   2015-06-14      LZMA Specification (Draft)

What's new:

> 16.02: Some bugs were fixed.
> 9.35: AES code and SFXs modules were included to SDK.
> 9.20: New small SFX module for installers.
> 9.11: PPMd support.
> 9.04: LZMA2 and XZ support.
> 4.62: LZMA SDK is placed in the public domain.
> 4.58: Speed optimizations. New ANSI-C code for LZMA compression.
> 4.57: Speed optimizations. Some fixes.
> 4.49: .7z ANSI-C decoder was improved. C++ code for .7z archive handling was included.

LZMA is the default and general compression method of 7z format in the 7-Zip program. LZMA provides a high compression ratio and very fast decompression, so it is very suitable for embedded applications. For example, it can be used for ROM (firmware) compressing.

LZMA SDK includes:
- C++ source code of LZMA Encoder and Decoder
- C++ source code for .7z compression and decompression (reduced version)
- ANSI-C compatible source code for LZMA / LZMA2 / XZ compression and decompression
- ANSI-C compatible source code for 7z decompression with example
- C# source code for LZMA compression and decompression
- Java source code for LZMA compression and decompression
- lzma.exe for .lzma compression and decompression
- 7zr.exe to work with 7z archives (reduced version of 7z.exe from 7-Zip)
- SFX modules to create self-extracting packages and installers

ANSI-C and C++ source code in LZMA SDK is subset of source code of 7-Zip.

LZMA features:
- Compression speed: 2 MB/s on 2 GHz dual-core CPU.
- Decompression speed:
- > 20-30 MB/s on modern 2 GHz CPU (Intel, AMD).
- > 5-10 MB/s on simple 1 GHz RISC CPU (ARM, MIPS, PowerPC).
- Small memory requirements for decompression: 8-32 KB + DictionarySize
- Small code size for decompression: 2-8 KB (depending on speed optimizations)

The LZMA decoder uses only CPU integer instructions and can be implemented for any modern 32-bit CPU (or, on a 16-bit CPU with some conditions).

License

LZMA SDK is placed in the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or distribute the original LZMA SDK code, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.

LZMA Links

> LZMA at Wikipedia
> Port of LZMA SDK for JAVA from independent developer
> Port of LZMA SDK to Pascal (Delphi, Kylix and Freepascal)
> PyLZMA: Python bindings for LZMA
> XZ Utils / LZMA utils
> LZMA Streams in Java
> LZMA Benchmark results for different CPUs

Copyright (C) 2016 Igor Pavlov. The site is hosted at Digital Ocean

[lzma-file-format.txt](https://github.com/sftt/precomp-cpp/files/322904/lzma-file-format.txt)
